### PR TITLE
tracker: handle send error

### DIFF
--- a/src/trackers/sort/simple_api.rs
+++ b/src/trackers/sort/simple_api.rs
@@ -151,11 +151,12 @@ impl Sort {
                 .foreign_track_distances(tracks.clone(), 0, false);
         assert!(errs.all().is_empty());
 
-        let (wasted_dists, _) =
+        let (wasted_dists, errs) =
             self.wasted_store
                 .write()
                 .unwrap()
                 .foreign_track_distances(tracks.clone(), 0, false);
+        assert!(errs.all().is_empty());
 
         let mut all_dists = dists.all();
         all_dists.extend(wasted_dists.all());


### PR DESCRIPTION
foreign_track_distances 함수 호출시 반환된 오류정보를 처리합니다.(https://github.com/nvrsw/ailab/issues/180)