### PR TITLE
kalman: adjust aspect ratio weight in kalmanfilter

### DIFF
--- a/src/utils/kalman/kalman_2d_box.rs
+++ b/src/utils/kalman/kalman_2d_box.rs
@@ -8,6 +8,7 @@ use nalgebra::{SMatrix, SVector};
 
 pub const DIM_2D_BOX: usize = 5;
 pub const DIM_2D_BOX_X2: usize = DIM_2D_BOX * 2;
+const ASPECT_WEIGHT: f32 = 0.5;
 
 /// Kalman filter
 ///
@@ -136,7 +137,7 @@ impl Universal2DBoxKalmanFilter {
             measurement.xc,
             measurement.yc,
             measurement.angle.unwrap_or(0.0),
-            measurement.aspect,
+            measurement.aspect * ASPECT_WEIGHT,
             measurement.height,
         ]) - projected_mean;
 
@@ -157,7 +158,7 @@ impl Universal2DBoxKalmanFilter {
                 measurement.xc,
                 measurement.yc,
                 measurement.angle.unwrap_or(0.0),
-                measurement.aspect,
+                measurement.aspect * ASPECT_WEIGHT,
                 measurement.height,
             ]);
             r.sub_assign(&mean);


### PR DESCRIPTION
새로운 트랙이 생성될 때 객체 박스의 가로세로 비율에 덜 민감하도록 
칼만 필터 2d box 계산에 사용되는 aspect ratio를 1/2로 조정합니다.(https://github.com/nvrsw/ailab/issues/186)